### PR TITLE
Convert2orion updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,20 @@
 
 
 ### A python package to convert python3 project into a NBAI task that can be executed by Nebula AI Worker.
-  
+
+This package will warp and convert your AI project into a NBAI task. 
+The sub-folders and files inside your project folder will be assumed 
+as part of your source codes and will be converted to a '.zip' file, excluding:
+   * hidden folders(e.g. '.git' or '.idea' folder) 
+   * python '__pycache__' folder
+   * Jupyter Notebook '.ipynb' files
+   
 This package includes two commands:
 ```
 - convert2or: Warp and convert python3 project files into a NBAI task that can be uploaded
  directly via NBAI Orion Platform and executed by Nebula AI Worker.
     
 - convert2py: Convert Jupyter Notebook '.ipynb' files into python3 '.py' files.
-
 ```
     
 ### Requirements
@@ -77,7 +83,7 @@ output response:
   **Note:**
 
     - Enter your project
-    - Enter command 'convert2or'
+    - Type command 'convert2or'
     
         Input parameters according to the prompt:
         1. 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@
 This package will warp and convert your AI project into a NBAI task. 
 The sub-folders and files inside your project folder will be assumed 
 as part of your source codes and will be converted to a '.zip' file, excluding:
-   * hidden folders(e.g. '.git' or '.idea' folder) 
+   * hidden folders(e.g. '.git', '.idea' folder) 
    * python '__pycache__' folder
+   * files starting with '.'
    * Jupyter Notebook '.ipynb' files
    
 This package includes two commands:

--- a/convert2orion_samples.md
+++ b/convert2orion_samples.md
@@ -262,7 +262,7 @@ The response looks like:
     Zipped files successfully!
 ```
 
-The task is named as 'word2vec_basic_orion.zip', also in the "task_files" folder.
+The task is named as 'word2vec_basic_orion.zip', also saved in the "task_files" folder.
     
 ##### Step 2: Upload this task via Orion Platform and have it executed by a Nebula AI Worker
 [Sign in as Nebula AI User](https://nbai.io/dashboard/#/login)
@@ -385,7 +385,7 @@ output is similar to the following:
     Zipped files successfully!
 ```
 
-The task is named as 'main_orion.zip', in the "task_files" folder.
+The task is named as 'main_orion.zip', saved in the "task_files" folder.
     
 ##### Step 2: Upload this task via Orion Platform and have it executed by a Nebula AI Worker
 [Sign in as Nebula AI User](https://nbai.io/dashboard/#/login)
@@ -410,5 +410,5 @@ time="2019-03-29 13:49:55" level=INFO msg="The result of
         Worker (0xE40c23cbEc97Ab0a63378954b827c04841C68370)."
 
 ```
-2. NBAI_output.log: No screen output, empty file.
+2. NBAI_output.log: No screen output, an empty file.
  

--- a/converter/converter.py
+++ b/converter/converter.py
@@ -15,14 +15,16 @@ def zip_folder(folder_path, output_path):
                              compression=zipfile.ZIP_DEFLATED) as zf:
             base_path = os.path.normpath(base_dir)
             for dirpath, dirnames, filenames in os.walk(base_dir):
-                for name in sorted(dirnames):
-                    path = os.path.normpath(os.path.join(dirpath, name))
-                    if ".ipynb" not in path:
-                        zf.write(path, os.path.relpath(path, base_path))
-                for name in filenames:
-                    path = os.path.normpath(os.path.join(dirpath, name))
+                dirnames[:] = [d for d in dirnames if not d[0] == '.' and "__pycache__" not in dirnames]
+                for dir_name in sorted(dirnames):
+                    path = os.path.normpath(os.path.join(dirpath, dir_name))
+                    zf.write(path, os.path.relpath(path, base_path))
+
+                filenames = [f for f in filenames if not f[0] == '.']
+                for f_name in filenames:
+                    path = os.path.normpath(os.path.join(dirpath, f_name))
                     if os.path.isfile(path):
-                        filename, file_extension = os.path.splitext(name)
+                        filename, file_extension = os.path.splitext(f_name)
                         if str(file_extension) != ".ipynb":
                             zf.write(path, os.path.relpath(path, base_path))
     except Exception as message:

--- a/converter/converter.py
+++ b/converter/converter.py
@@ -226,7 +226,7 @@ def convert2or():
                 p.wait()
                 time.sleep(1)
 
-                # fix the bug raising from 'tensorflow', 'tensorflow_gpu' and "tensorflow-gpu>1.12.0"
+                # fix the bug raising from 'tensorflow', 'tensorflow_gpu'
                 filename = os.path.join(workspace_dir, "requirements.txt")
 
                 rw_file(filename, matplotlib="matplotlib", tensorflow_gpu="", tensorflow="tensorflow-gpu")


### PR DESCRIPTION
  conversion ignores the following items:

   * hidden folders(e.g. '.git' or '.idea' folder) 
   * python '__pycache__' folder
   * files starting with '.'
   * Jupyter Notebook '.ipynb' files